### PR TITLE
Fix a minor 'go vet' error in httpcommon.go

### DIFF
--- a/dfc/httpcommon.go
+++ b/dfc/httpcommon.go
@@ -141,7 +141,8 @@ func (r *httprunner) run() error {
 func (r *httprunner) stop(err error) {
 	glog.Infof("Stopping %s, err: %v", r.name, err)
 
-	contextwith, _ := context.WithTimeout(context.Background(), ctx.config.HttpTimeout)
+	contextwith, cancel := context.WithTimeout(context.Background(), ctx.config.HttpTimeout)
+	defer cancel()
 
 	err = r.h.Shutdown(contextwith)
 	if err != nil {


### PR DESCRIPTION
This commit will fix the following error by adding 'defer cancel()'

```
httpcommon.go:144: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
```

C.f.) https://golang.org/pkg/context/#WithTimeout