### PR TITLE
Use struct instead of 4 individual data in call()'s return

### DIFF
--- a/dfc/daemon.go
+++ b/dfc/daemon.go
@@ -103,6 +103,7 @@ type (
 
 	// callResult contains data returned by a server to server call
 	callResult struct {
+		si      *daemonInfo
 		outjson []byte
 		err     error
 		errstr  string

--- a/dfc/httpcommon.go
+++ b/dfc/httpcommon.go
@@ -309,7 +309,7 @@ func (h *httprunner) call(rOrig *http.Request, si *daemonInfo, url, method strin
 
 	if err != nil {
 		errstr = fmt.Sprintf("Unexpected failure to create http request %s %s, err: %v", method, url, err)
-		return callResult{outjson, err, errstr, status}
+		return callResult{si, outjson, err, errstr, status}
 	}
 
 	copyHeaders(rOrig, request)
@@ -330,11 +330,11 @@ func (h *httprunner) call(rOrig *http.Request, si *daemonInfo, url, method strin
 		if response != nil && response.StatusCode > 0 {
 			errstr = fmt.Sprintf("Failed to http-call %s (%s %s): status %s, err %v", sid, method, url, response.Status, err)
 			status = response.StatusCode
-			return callResult{outjson, err, errstr, status}
+			return callResult{si, outjson, err, errstr, status}
 		}
 
 		errstr = fmt.Sprintf("Failed to http-call %s (%s %s): err %v", sid, method, url, err)
-		return callResult{outjson, err, errstr, status}
+		return callResult{si, outjson, err, errstr, status}
 	}
 
 	assert(response != nil, "Unexpected: nil response with no error")
@@ -349,7 +349,7 @@ func (h *httprunner) call(rOrig *http.Request, si *daemonInfo, url, method strin
 			}
 		}
 
-		return callResult{outjson, err, errstr, status}
+		return callResult{si, outjson, err, errstr, status}
 	}
 
 	// err == nil && bad status: response.Body contains the error message
@@ -357,14 +357,14 @@ func (h *httprunner) call(rOrig *http.Request, si *daemonInfo, url, method strin
 		err = fmt.Errorf("%s, status code: %d", outjson, response.StatusCode)
 		errstr = err.Error()
 		status = response.StatusCode
-		return callResult{outjson, err, errstr, status}
+		return callResult{si, outjson, err, errstr, status}
 	}
 
 	if sid != "unknown" {
 		h.kalive.timestamp(sid)
 	}
 
-	return callResult{outjson, err, errstr, status}
+	return callResult{si, outjson, err, errstr, status}
 }
 
 //=============================

--- a/dfc/metasync.go
+++ b/dfc/metasync.go
@@ -271,16 +271,16 @@ func (y *metasyncer) dosync(revsvec []interface{}) int {
 	return len(y.pending.diamonds)
 }
 
-func (y *metasyncer) callbackSync(si *daemonInfo, _ []byte, err error, status int) {
-	if err == nil {
+func (y *metasyncer) callbackSync(res callResult) {
+	if res.err == nil {
 		return
 	}
-	glog.Warningf("Failed to sync %s, err: %v (%d)", si.DaemonID, err, status)
+	glog.Warningf("Failed to sync %s, err: %v (%d)", res.si.DaemonID, res.err, res.status)
 
 	y.pending.lock.Lock()
-	y.pending.diamonds[si.DaemonID] = si
-	if IsErrConnectionRefused(err) {
-		y.pending.refused[si.DaemonID] = si
+	y.pending.diamonds[res.si.DaemonID] = res.si
+	if IsErrConnectionRefused(res.err) {
+		y.pending.refused[res.si.DaemonID] = res.si
 	}
 	y.pending.lock.Unlock()
 }


### PR DESCRIPTION
@VladimirMarkelov @alex-aizman @sasanap @liangdrew 
no logic change, just better code, and returning result in on struct make sit possible to pass the result to a channel for other uses