### PR TITLE
Primary proxy change

### DIFF
--- a/dfc/httpcommon.go
+++ b/dfc/httpcommon.go
@@ -138,7 +138,6 @@ type httprunner struct {
 	httpclientLongTimeout *http.Client // http client for long-wait intra-cluster comm
 	statsif               statsif
 	kalive                kaliveif
-	proxysi               *proxyInfo
 	smap                  *Smap
 	lbmap                 *lbmap
 }
@@ -186,7 +185,6 @@ func (h *httprunner) init(s statsif, isproxy bool) {
 	h.smap = &Smap{}
 	h.lbmap = &lbmap{LBmap: make(map[string]string)} // local (aka cache-only) buckets
 
-	h.proxysi = &proxyInfo{}
 	// init daemonInfo here
 	h.si = &daemonInfo{}
 	h.si.NodeIPAddr = ipaddr

--- a/dfc/keeper.go
+++ b/dfc/keeper.go
@@ -210,7 +210,7 @@ func (r *proxykalive) keepalive(err error) (stopped bool) {
 		return r.primarykeepalive(err)
 	}
 
-	if r.p.proxysi == nil || r.skipCheck(r.p.proxysi.DaemonID) {
+	if r.p.smap.ProxySI == nil || r.skipCheck(r.p.smap.ProxySI.DaemonID) {
 		return
 	}
 	stopped = keepalive(r.p, r.controlCh, err)
@@ -317,7 +317,7 @@ func (r *proxykalive) poll(si *daemonInfo, url string) (responded, stopped bool)
 //
 //===========================================
 func (r *targetkalive) keepalive(err error) (stopped bool) {
-	if r.t.proxysi == nil || r.skipCheck(r.t.proxysi.DaemonID) {
+	if r.t.smap.ProxySI == nil || r.skipCheck(r.t.smap.ProxySI.DaemonID) {
 		return
 	}
 	stopped = keepalive(r.t, r.controlCh, err)

--- a/dfc/metasync.go
+++ b/dfc/metasync.go
@@ -125,8 +125,8 @@ func (y *metasyncer) sync(wait bool, revsvec ...interface{}) {
 	assert(y.p != nil)
 	if !y.p.primary {
 		lead := "?"
-		if y.p.proxysi != nil {
-			lead = y.p.proxysi.DaemonID
+		if y.p.smap.ProxySI != nil {
+			lead = y.p.smap.ProxySI.DaemonID
 		}
 		glog.Errorf("%s (self) is not the primary proxy (%s) - cannot distribute REVS", y.p.si.DaemonID, lead)
 		return

--- a/dfc/target.go
+++ b/dfc/target.go
@@ -180,8 +180,8 @@ func (t *targetrunner) register(timeout time.Duration) (int, error) {
 	}
 
 	var url string
-	if t.proxysi.DaemonID != "" {
-		url = t.proxysi.DirectURL
+	if t.smap.ProxySI != nil && t.smap.ProxySI.DaemonID != "" {
+		url = t.smap.ProxySI.DirectURL
 	} else {
 		// Smap has not yet been synced:
 		url = ctx.config.Proxy.Primary.URL
@@ -189,8 +189,8 @@ func (t *targetrunner) register(timeout time.Duration) (int, error) {
 
 	url += "/" + Rversion + "/" + Rcluster
 	var si *daemonInfo
-	if t.proxysi != nil {
-		si = &t.proxysi.daemonInfo
+	if t.smap.ProxySI != nil {
+		si = &t.smap.ProxySI.daemonInfo
 	}
 
 	var res callResult
@@ -206,14 +206,14 @@ func (t *targetrunner) register(timeout time.Duration) (int, error) {
 
 func (t *targetrunner) unregister() (int, error) {
 	var url string
-	if t.proxysi.DaemonID != "" {
-		url = t.proxysi.DirectURL
+	if t.smap.ProxySI.DaemonID != "" {
+		url = t.smap.ProxySI.DirectURL
 	} else {
 		// Smap has not yet been synched:
 		url = ctx.config.Proxy.Primary.URL
 	}
 	url += "/" + Rversion + "/" + Rcluster + "/" + Rdaemon + "/" + t.si.DaemonID
-	res := t.call(nil, &t.proxysi.daemonInfo, url, http.MethodDelete, nil)
+	res := t.call(nil, &t.smap.ProxySI.daemonInfo, url, http.MethodDelete, nil)
 	return res.status, res.err
 }
 
@@ -758,8 +758,8 @@ func (t *targetrunner) httphealth(w http.ResponseWriter, r *http.Request) {
 	jsbytes, err := json.Marshal(status)
 	assert(err == nil, err)
 	ok := t.writeJSON(w, r, jsbytes, "thealthstatus")
-	if ok && from == t.proxysi.DaemonID {
-		t.kalive.timestamp(t.proxysi.DaemonID)
+	if ok && from == t.smap.ProxySI.DaemonID {
+		t.kalive.timestamp(t.smap.ProxySI.DaemonID)
 	}
 }
 

--- a/dfc/tests/proxy_test.go
+++ b/dfc/tests/proxy_test.go
@@ -573,6 +573,17 @@ func targetMapVersionMismatch(getNum func(int) int, t *testing.T) {
 func concurrentPutGetDel(t *testing.T) {
 	smap := getClusterMap(httpclient, t)
 
+	exists, err := client.DoesLocalBucketExist(proxyurl, localBucketName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		err := client.CreateLocalBucket(proxyurl, localBucketName)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	var (
 		errch = make(chan error, len(smap.Pmap))
 		wg    sync.WaitGroup
@@ -594,6 +605,7 @@ func concurrentPutGetDel(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	client.DestroyLocalBucket(proxyurl, localBucketName)
 }
 
 // proxyPutGetDelete repeats put/get/del N times, all requests go to the same proxy
@@ -765,9 +777,15 @@ func proxyStress(t *testing.T) {
 		wg          sync.WaitGroup
 	)
 
-	err := client.CreateLocalBucket(proxyurl, localBucketName)
+	exists, err := client.DoesLocalBucketExist(proxyurl, localBucketName)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !exists {
+		err := client.CreateLocalBucket(proxyurl, localBucketName)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// start all workers


### PR DESCRIPTION
We had two places to keep the current primary proxy. Most of the time they contained the same value. But it was confusing and it was hard to get what and where to change. The patch leaves only one place to keep primary proxy. With the patch proxy test suit passes more test than the code with 2 places: 8/10 against 5/10. Only putGet & stress are failing. 
The proxy test is still disabled.