### PR TITLE
Multi-proxy test

### DIFF
--- a/dfc/proxy.go
+++ b/dfc/proxy.go
@@ -168,6 +168,11 @@ func (p *proxyrunner) run() error {
 	// startup: register and sync across
 	if p.primary {
 		go p.clusterStartup(clivars.ntargets)
+	} else {
+		// Since it is secondary proxy and it has registered successfully at
+		// primary proxy then it is safe to think that the cluster had already
+		// started up.
+		p.startedup = true
 	}
 
 	//


### PR DESCRIPTION
1. Fixed bug when changing primary after the original primary crashed did not work (a one-liner in proxy.go)
2. Multiproxy tests are enabled but only 2 sub-tests work stable, so other sub-tests are disabled for now. With the patch 'go test ... run=Proxy' can be executed as many times as you want.
3. Added test to set original primary back after it crashes (with some hacks to detect original proxy in Smap)
4. Added extra check for multiproxy tests: check if all proxy have the same version of Smap