### PR TITLE
Add test for GET after file corruption in cache

### DIFF
--- a/dfc/config.go
+++ b/dfc/config.go
@@ -23,8 +23,8 @@ const (
 
 // checksums: xattr, http header, and config
 const (
-	xattrXXHashVal  = "user.obj.dfchash"
-	xattrObjVersion = "user.obj.version"
+	XattrXXHashVal  = "user.obj.dfchash"
+	XattrObjVersion = "user.obj.version"
 
 	ChecksumNone   = "none"
 	ChecksumXXHash = "xxhash"

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -285,11 +285,12 @@ func get(proxyurl, bucket string, keyname string, wg *sync.WaitGroup, errch chan
 
 	v := hdhashtype == dfc.ChecksumXXHash
 	len, hash, err := readResponse(resp, w, err, fmt.Sprintf("GET (object %s from bucket %s)", keyname, bucket), v)
-	if err != nil && v {
+	if v {
 		if hdhash != hash {
 			s := fmt.Sprintf("Header's hash %s doesn't match the file's %s \n", hdhash, hash)
+			err = errors.New(s)
 			if errch != nil {
-				errch <- errors.New(s)
+				errch <- err
 			}
 		} else {
 			if !silent {


### PR DESCRIPTION
~Also adding object FQN as a response header to the HEAD object API (so that it can be used to corrupt the test files).~ Traversing the directory tree to find FQNs.