### PR TITLE
Misc metasync code changes

### DIFF
--- a/dfc/daemon.go
+++ b/dfc/daemon.go
@@ -223,6 +223,12 @@ func (m *Smap) deepcopy(dst *Smap) {
 	copyStruct(dst.ProxySI, m.ProxySI)
 }
 
+// totalServers returns total number of proxies plus targets.
+// no lock held.
+func (m *Smap) totalServers() int {
+	return len(m.Pmap) + len(m.Tmap)
+}
+
 // Dump prints the smap
 func (m *Smap) Dump() {
 	fmt.Printf("Smap: version = %d\n", m.Version)


### PR DESCRIPTION
1. Consolidate pending check in one place.
2. Modified pending handler and refused handler logic by using channel instead of lock. Using lock has a race between
   the actual for loop and the callbacks.
3. Added a small delay in the refused test case, a small % of the test didn't go to that route, this delay
   helps to make it happen as the test case is designed for.
4. Fixed a few locking issue in test code