### PR TITLE
add more logging to voting process

### DIFF
--- a/dfc/tests/proxy_test.go
+++ b/dfc/tests/proxy_test.go
@@ -1304,6 +1304,9 @@ func (p *voteRetryMockTarget) votehdlr(w http.ResponseWriter, r *http.Request) {
 
 // primarySetToOriginal reads original primary proxy from configuration and
 // makes it a primary proxy again
+// NOTE: This test cannot be run as separate test. It requires that original
+// primary proxy was down and retuned back. So, the test should be executed
+// after primaryCrash test
 func primarySetToOriginal(t *testing.T) {
 	smap := getClusterMap(httpclient, t)
 	tlogf("SMAP version at start: %d\n", smap.Version)


### PR DESCRIPTION
Vote.go had a lot of logging before the PR. I've added log calls in places that are not error to better follow the process.
Two little issues fixed: 
- replaced err with sid in one place because err there is not available or unrelated and added logging error while pinging current primary