### PR TITLE
Add option to get target URL on list bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,16 +235,16 @@ More usage examples can be found in the [the source](dfc/tests/regression_test.g
 
 ## List Bucket
 
-the ListBucket API returns a page of object names (and, optionally, their properties including sizes, creation times, checksums, and more), in addition to a token allowing the next page to be retrieved.
+The ListBucket API returns a page of object names (and, optionally, their properties including sizes, creation times, checksums, and more), in addition to a token allowing the next page to be retrieved.
 
 ### properties-and-options
 The properties-and-options specifier must be a JSON-encoded structure, for instance '{"props": "size"}' (see examples). An empty structure '{}' results in getting just the names of the objects (from the specified bucket) with no other metadata.
 
 | Property/Option | Description | Value |
 | --- | --- | --- |
-| props | The properties to return with object names | A comma-separated string containing any combination of: "checksum","size","atime","ctime","iscached","bucket","version". <sup id="a6">[6](#ft6)</sup> |
+| props | The properties to return with object names | A comma-separated string containing any combination of: "checksum","size","atime","ctime","iscached","bucket","version","targetUrl". <sup id="a6">[6](#ft6)</sup> |
 | time_format | The standard by which times should be formatted | Any of the following [golang time constants](http://golang.org/pkg/time/#pkg-constants): RFC822, Stamp, StampMilli, RFC822Z, RFC1123, RFC1123Z, RFC3339. The default is RFC822. |
-| prefix | The prefix which all returned objects must have. | For example, "my/directory/structure/" |
+| prefix | The prefix which all returned objects must have | For example, "my/directory/structure/" |
 | pagemarker | The token identifying the next page to retrieve | Returned in the "nextpage" field from a call to ListBucket that does not retrieve all keys. When the last key is retrieved, NextPage will be the empty string |
 | pagesize | The maximum number of object names returned in response | Default value is 1000. GCP and local bucket support greater page sizes. AWS is unable to return more than [1000 objects in one page](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html). |\b
 

--- a/dfc/REST.go
+++ b/dfc/REST.go
@@ -149,6 +149,7 @@ const (
 	GetPropsIsCached = "iscached"
 	GetPropsBucket   = "bucket"
 	GetPropsVersion  = "version"
+	GetTargetURL     = "targetUrl"
 )
 
 //===================
@@ -160,18 +161,19 @@ const (
 // BucketEntry corresponds to a single entry in the BucketList and
 // contains file and directory metadata as per the GetMsg
 type BucketEntry struct {
-	Name     string `json:"name"`     // name of the object - note: does not include the bucket name
-	Size     int64  `json:"size"`     // size in bytes
-	Ctime    string `json:"ctime"`    // formatted as per GetMsg.GetTimeFormat
-	Checksum string `json:"checksum"` // checksum
-	Type     string `json:"type"`     // "file" OR "directory"
-	Atime    string `json:"atime"`    // formatted as per GetMsg.GetTimeFormat
-	Bucket   string `json:"bucket"`   // parent bucket name
-	Version  string `json:"version"`  // version/generation ID. In GCP it is int64, in AWS it is a string
-	IsCached bool   `json:"iscached"` // if the file is cached on one of targets
+	Name      string `json:"name"`                // name of the object - note: does not include the bucket name
+	Size      int64  `json:"size"`                // size in bytes
+	Ctime     string `json:"ctime"`               // formatted as per GetMsg.GetTimeFormat
+	Checksum  string `json:"checksum"`            // checksum
+	Type      string `json:"type"`                // "file" OR "directory"
+	Atime     string `json:"atime"`               // formatted as per GetMsg.GetTimeFormat
+	Bucket    string `json:"bucket"`              // parent bucket name
+	Version   string `json:"version"`             // version/generation ID. In GCP it is int64, in AWS it is a string
+	IsCached  bool   `json:"iscached"`            // if the file is cached on one of targets
+	TargetURL string `json:"targetURL,omitempty"` // URL of target which has the entry
 }
 
-// BucketList represents the contents of a given bucket - somewhat analagous to the 'ls <bucket-name>'
+// BucketList represents the contents of a given bucket - somewhat analogous to the 'ls <bucket-name>'
 type BucketList struct {
 	Entries    []*BucketEntry `json:"entries"`
 	PageMarker string         `json:"pagemarker"`

--- a/dfc/gcp.go
+++ b/dfc/gcp.go
@@ -194,9 +194,11 @@ func (gcpimpl *gcpimpl) listbucket(ct context.Context, bucket string, msg *GetMs
 
 		reslist.Entries = append(reslist.Entries, entry)
 	}
+
 	if glog.V(4) {
 		glog.Infof("listbucket count %d", len(reslist.Entries))
 	}
+
 	jsbytes, err = json.Marshal(reslist)
 	assert(err == nil, err)
 	return

--- a/dfc/proxy.go
+++ b/dfc/proxy.go
@@ -23,6 +23,8 @@ import (
 	"syscall"
 	"time"
 
+	"errors"
+
 	"github.com/NVIDIA/dfcpub/dfc/statsd"
 	"github.com/golang/glog"
 )
@@ -1190,7 +1192,16 @@ func (p *proxyrunner) getCloudBucketObjects(r *http.Request, bucket string, list
 	if len(allentries.Entries) == 0 {
 		return
 	}
-
+	if strings.Contains(msg.GetProps, GetTargetURL) {
+		for _, e := range allentries.Entries {
+			si, errStr := HrwTarget(bucket, e.Name, p.smap)
+			if errStr != "" {
+				err = errors.New(errStr)
+				return
+			}
+			e.TargetURL = si.DirectURL
+		}
+	}
 	if strings.Contains(msg.GetProps, GetPropsAtime) ||
 		strings.Contains(msg.GetProps, GetPropsIsCached) {
 		// Now add local properties to the cloud objects

--- a/dfc/target.go
+++ b/dfc/target.go
@@ -1243,6 +1243,11 @@ func (t *targetrunner) prepareLocalObjectList(bucket string, msg *GetMsg) (bucke
 		Entries:    allfinfos,
 		PageMarker: marker,
 	}
+	if strings.Contains(msg.GetProps, GetTargetURL) {
+		for _, e := range bucketList.Entries {
+			e.TargetURL = t.si.DirectURL
+		}
+	}
 	return bucketList, nil
 }
 


### PR DESCRIPTION
Also add local and cloud bucket tests and update the README.

~An updated README (for this advanced usage) will come after.~ Also, PUT requests sent directly to the target (i.e. not from a proxy) will be disallowed in a following patch to prevent abuse.