### PR TITLE
Allows detecting server timeout/failure using different/configurable …

### DIFF
--- a/dfc/fskeeper.go
+++ b/dfc/fskeeper.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -20,6 +21,11 @@ const (
 	tmpDirnameTemplate  = "DFC-TEMP-DIR"
 	tmpFilenameTemplate = "DFC-TEMP-FILE"
 )
+
+type okmap struct {
+	sync.Mutex
+	okmap map[string]time.Time
+}
 
 type fskeeper struct {
 	namedrunner

--- a/dfc/httpcommon.go
+++ b/dfc/httpcommon.go
@@ -365,7 +365,7 @@ func (h *httprunner) call(rOrig *http.Request, si *daemonInfo, url, method strin
 	}
 
 	if sid != "unknown" {
-		h.kalive.timestamp(sid)
+		h.kalive.heardFrom(sid, true /* reset */)
 	}
 
 	return callResult{si, outjson, err, errstr, status}

--- a/dfc/keepalivetracker.go
+++ b/dfc/keepalivetracker.go
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+ */
+
+package dfc
+
+// This file has different implementations of KeepaliveTracker.
+// ideally this file stays under dfcpub, but currently dfc has a flat structure, following that
+// for now.
+import (
+	"time"
+)
+
+// HeartBeatTracker tracks timestamp of the last a message is received from a server.
+// Timeout: a message is not received within the interval.
+type HeartBeatTracker struct {
+	ch       chan struct{}
+	last     map[string]time.Time
+	interval time.Duration // expected to hear from the server within the interval
+}
+
+// NewHeartBeatTracker returns a HeartBeatTracker
+func NewHeartBeatTracker(interval time.Duration) *HeartBeatTracker {
+	hb := &HeartBeatTracker{last: make(map[string]time.Time), ch: make(chan struct{}, 1)}
+	hb.interval = interval
+	hb.unlock()
+	return hb
+}
+
+func (hb *HeartBeatTracker) lock() {
+	<-hb.ch
+}
+
+func (hb *HeartBeatTracker) unlock() {
+	hb.ch <- struct{}{}
+}
+
+// HeardFrom is called to indicate a keepalive message (or equivalent) is received from a server
+func (hb *HeartBeatTracker) HeardFrom(id string, reset bool) {
+	hb.lock()
+	defer hb.unlock()
+
+	hb.last[id] = time.Now()
+}
+
+// TimedOut returns true if it is determined that have not heard from the server
+func (hb *HeartBeatTracker) TimedOut(id string) bool {
+	hb.lock()
+	defer hb.unlock()
+
+	t, ok := hb.last[id]
+	return !ok || time.Since(t) > hb.interval
+}
+
+// AverageTracker keeps track of the average latency of all messages.
+// Timeout: last received is more than the 'factor' of current average.
+type AverageTracker struct {
+	ch     chan struct{}
+	rec    map[string]averageTrackerRecord
+	factor int
+}
+
+type averageTrackerRecord struct {
+	cnt     int64
+	last    time.Time
+	totalMS int64 // in ms
+}
+
+func (rec *averageTrackerRecord) avg() int64 {
+	return rec.totalMS / rec.cnt
+}
+
+// NewAverageTracker returns a AverageTracker
+func NewAverageTracker(factor int) *AverageTracker {
+	a := &AverageTracker{rec: make(map[string]averageTrackerRecord), ch: make(chan struct{}, 1)}
+	a.factor = factor
+	a.unlock()
+	return a
+}
+
+func (a *AverageTracker) lock() {
+	<-a.ch
+}
+
+func (a *AverageTracker) unlock() {
+	a.ch <- struct{}{}
+}
+
+// HeardFrom is called to indicate a keepalive message (or equivalent) is received from a server
+func (a *AverageTracker) HeardFrom(id string, reset bool) {
+	a.lock()
+	defer a.unlock()
+
+	var rec averageTrackerRecord
+	rec, ok := a.rec[id]
+	if reset || !ok {
+		a.rec[id] = averageTrackerRecord{cnt: 0, totalMS: 0, last: time.Now()}
+		return
+	}
+
+	t := time.Now()
+	delta := t.Sub(rec.last)
+	rec.last = t
+	rec.cnt++
+	rec.totalMS += int64(delta / time.Millisecond)
+	a.rec[id] = rec
+}
+
+// TimedOut returns true if it is determined that have not heard from the server
+func (a *AverageTracker) TimedOut(id string) bool {
+	a.lock()
+	defer a.unlock()
+
+	rec, ok := a.rec[id]
+	if !ok {
+		return true
+	}
+
+	if rec.cnt == 0 {
+		return false
+	}
+
+	return int64(time.Now().Sub(rec.last)/time.Millisecond) > int64(a.factor)*rec.avg()
+}
+
+var (
+	_ KeepaliveTracker = &HeartBeatTracker{}
+	_ KeepaliveTracker = &AverageTracker{}
+)

--- a/dfc/metasync_test.go
+++ b/dfc/metasync_test.go
@@ -85,6 +85,7 @@ func newPrimary() *proxyrunner {
 	pi := &proxyInfo{daemonInfo{DaemonID: p.si.DaemonID, DirectURL: "do not care"}, true /* primary */}
 	p.smap.addProxy(pi)
 	p.smap.ProxySI = pi
+	p.kalive = newproxykalive(&p)
 	return &p
 }
 

--- a/dfc/proxy.go
+++ b/dfc/proxy.go
@@ -1822,11 +1822,13 @@ func (p *proxyrunner) shouldAddToSmap(nsi *daemonInfo, osi *daemonInfo, keepaliv
 			glog.Warningf("register/keepalive %s %s: adding back to the cluster map", kind, nsi.DaemonID)
 			return true
 		}
+
 		if osi.NodeIPAddr != nsi.NodeIPAddr || osi.DaemonPort != nsi.DaemonPort {
 			glog.Warningf("register/keepalive %s %s: info changed - renewing", kind, nsi.DaemonID)
 			return true
 		}
-		p.kalive.timestamp(nsi.DaemonID)
+
+		p.kalive.heardFrom(nsi.DaemonID, !keepalive /* reset */)
 		return false
 	}
 	if osi != nil {

--- a/dfc/target.go
+++ b/dfc/target.go
@@ -760,7 +760,7 @@ func (t *targetrunner) httphealth(w http.ResponseWriter, r *http.Request) {
 	assert(err == nil, err)
 	ok := t.writeJSON(w, r, jsbytes, "thealthstatus")
 	if ok && from == t.smap.ProxySI.DaemonID {
-		t.kalive.timestamp(t.smap.ProxySI.DaemonID)
+		t.kalive.heardFrom(t.smap.ProxySI.DaemonID, false /* reset */)
 	}
 }
 

--- a/dfc/vote.go
+++ b/dfc/vote.go
@@ -571,14 +571,11 @@ func (h *httprunner) sendElectionRequest(vr *VoteInitiation, nextPrimaryProxy *p
 func (h *httprunner) voteOnProxy(daemonID, currPrimaryID string) (bool, error) {
 	// First: Check last keepalive timestamp. If the proxy was recently successfully reached,
 	// this will always vote no, as we believe the original proxy is still alive.
-	lastKeepaliveTime := h.kalive.getTimestamp(currPrimaryID)
-	timeSinceLastKalive := time.Since(lastKeepaliveTime)
-	if timeSinceLastKalive < ctx.config.Periodic.KeepAliveTime/2 {
-		// KeepAliveTime/2 is the expected amount time since the last keepalive was sent
+	if !h.kalive.timedOut(currPrimaryID) {
 		if glog.V(4) {
-			glog.Warningf("Primary was alive only %v ago (should be down for at least %v)",
-				timeSinceLastKalive, ctx.config.Periodic.KeepAliveTime/2)
+			glog.Warningf("Primary %s is still alive", currPrimaryID)
 		}
+
 		return false, nil
 	}
 


### PR DESCRIPTION
…stratergy

1. code cleanup
2. fix a bug or may be unintentional behavior
   current code works in term of keeping target and primary proxy alive and communicate each
   other, but i doubt it is the intention, here is how current code works:
   a. target send keepalive every 20s if there is no communication with primary for the past 20s
   b. primary receives keepalive from target, all good
   c. next target keepalive come in 20.000009s, primary thinks it is late(by .000009), so it asks
      target for a health check.
   d. target receives the health check, mark down the time last communicated with primary
      primary also records down the time it has communicated with the target triggered by the health
      check which is a register call
   e. 20s passed, target suppose to send keepalive, but it found out that it has communicated with
      primary just recently, so it skips the keepalive
   f. primary keepalive found out there is no keepalive, health check again
   so the actual keep alive between pimary and target is like kept alive by the sequence of:
   keepalive, health check, health check, keepalive, etc, random sequence
   i fixed it by letting target always send keepalive on the fixed time, no skipping, also record
   last communicate time with primary after a successful keepalive, this makes the keepalive sequence
   between primary and target as:
   keepalive, keepalive, keepalive, ... no health check at all unless abnormal things happen
3. new interface KeepaliveTracker to allow plugable failure detection
4. new average keepalive interval tracker(not used yet, requires config file change,
   will do in follow up change)
5. unit test cases for the two keepalive tracker implementation


@VladimirMarkelov @liangdrew @sasanap @alex-aizman 
Thanks
