### PR TITLE
Clean up tests

### DIFF
--- a/dfc/tests/integration_test.go
+++ b/dfc/tests/integration_test.go
@@ -85,7 +85,7 @@ func TestGetAndReRegisterInParallel(t *testing.T) {
 	err = client.UnregisterTarget(proxyurl, m.sid)
 	checkFatal(err, t)
 
-	n := len(getClusterMap(httpclient, t).Tmap)
+	n := len(getClusterMap(t).Tmap)
 	if n != m.origNumTargets-1 {
 		t.Fatalf("%d targets expected after unregister, actually %d targets", m.origNumTargets-1, n)
 	}
@@ -180,7 +180,7 @@ func TestProxyFailbackAndGetAndReRegisterInParallel(t *testing.T) {
 
 	err = client.UnregisterTarget(proxyurl, m.sid)
 	checkFatal(err, t)
-	n := len(getClusterMap(httpclient, t).Tmap)
+	n := len(getClusterMap(t).Tmap)
 	if n != m.origNumTargets-1 {
 		t.Fatalf("%d targets expected after unregister, actually %d targets", m.origNumTargets-1, n)
 	}
@@ -294,7 +294,7 @@ func doReregisterTarget(m *metadata) {
 PollLoop:
 	for i := 0; i < 25; i++ {
 		time.Sleep(time.Second)
-		m.smap = getClusterMap(httpclient, m.t)
+		m.smap = getClusterMap(m.t)
 
 		if len(m.smap.Tmap) == m.origNumTargets {
 			lbNames, err := client.GetLocalBucketNames(m.targetDirectURL)

--- a/dfc/tests/objprops_test.go
+++ b/dfc/tests/objprops_test.go
@@ -210,7 +210,7 @@ func propsRecacheObjects(t *testing.T, bucket string, objs map[string]string, ms
 func propsRebalance(t *testing.T, bucket string, objects map[string]string, msg *dfc.GetMsg, versionEnabled bool, isLocalBucket bool) {
 	propsCleanupObjects(t, bucket, objects)
 
-	smap := getClusterMap(httpclient, t)
+	smap := getClusterMap(t)
 	l := len(smap.Tmap)
 	if l < 2 {
 		t.Skipf("Only %d targets found, need at least 2", l)
@@ -237,13 +237,13 @@ func propsRebalance(t *testing.T, bucket string, objects map[string]string, msg 
 	checkFatal(err, t)
 	for i := 0; i < 25; i++ {
 		time.Sleep(time.Second)
-		smap = getClusterMap(httpclient, t)
+		smap = getClusterMap(t)
 		if len(smap.Tmap) == l {
 			break
 		}
 	}
 
-	smap = getClusterMap(httpclient, t)
+	smap = getClusterMap(t)
 	if l != len(smap.Tmap) {
 		t.Errorf("Target failed to reregister. Current number of targets: %d (expected %d)", len(smap.Tmap), l)
 	}


### PR DESCRIPTION
1. Remove unused httpclient from getClusterMap()
2. Replace basic t.Fatal() with checkFatal()
3. Defer DestroyLocalBucket where not done previously
4. Use better corrupted xattr name for test