### PR TITLE
Fix a race in LoadSave() local config

### DIFF
--- a/dfc/utils.go
+++ b/dfc/utils.go
@@ -353,6 +353,8 @@ func (v *cksumvalxxhash) get() (string, string) { return v.tag, v.val }
 
 func (v *cksumvalmd5) get() (string, string) { return v.tag, v.val }
 
+// Li. Ding: LocalSave is not multi-thread safe, caller is responsible for serializing concurrent calls.
+
 //===========================================================================
 //
 // local (config) save and restore

--- a/dfc/vote.go
+++ b/dfc/vote.go
@@ -632,13 +632,10 @@ func (h *httprunner) setPrimaryProxy(newPrimaryProxy, primaryToRemove string, pr
 	ctx.config.Proxy.Primary.ID = proxyinfo.DaemonID
 	ctx.config.Proxy.Primary.URL = proxyinfo.DirectURL
 
-	go func() {
-		glog.Infof("Set primary proxy: %v (prepare: %t)", newPrimaryProxy, prepare)
-		err := LocalSave(clivars.conffile, ctx.config)
-		if err != nil {
-			glog.Errorf("Error writing config file: %v", err)
-		}
-	}()
+	err := LocalSave(clivars.conffile, ctx.config)
+	if err != nil {
+		glog.Errorf("Error writing config file: %v", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This is the error happens when running multi proxy tests:
"Error writing config file: rename /Users/liding/.dfc2/dfc.json.tmp /Users/liding/.dfc2/dfc.json:
 no such file or directory"

Reason for this is setPrimaryProxy() call LoadSave() in a go routine, but LoadSave() is not concurrent
safe. The concurrent calls of setPrimaryProxy() are from metasync by the new primary proxy while the
original primary proxy still in the middle of httpclusetprimaryproxy().

@VladimirMarkelov @liangdrew @sasanap @alex-aizman 