### PR TITLE
remove unused field

### DIFF
--- a/dfc/daemon.go
+++ b/dfc/daemon.go
@@ -45,8 +45,8 @@ type (
 	// Smap contains id:daemonInfo pairs and related metadata
 	Smap struct {
 		Tmap    map[string]*daemonInfo `json:"tmap"` // daemonID -> daemonInfo
-		Pmap    map[string]*proxyInfo  `json:"pmap"` // proxyID -> proxyInfo
-		ProxySI *proxyInfo             `json:"proxy_si"`
+		Pmap    map[string]*daemonInfo `json:"pmap"` // proxyID -> proxyInfo
+		ProxySI *daemonInfo            `json:"proxy_si"`
 		Version int64                  `json:"version"`
 	}
 
@@ -69,11 +69,6 @@ type (
 		DaemonPort string `json:"daemon_port"`
 		DaemonID   string `json:"daemon_id"`
 		DirectURL  string `json:"direct_url"`
-	}
-
-	proxyInfo struct {
-		daemonInfo
-		Primary bool
 	}
 
 	// local (cache-only) bucket names and their TBD props
@@ -136,7 +131,7 @@ func (m *Smap) add(si *daemonInfo) {
 	m.Version++
 }
 
-func (m *Smap) addProxy(pi *proxyInfo) {
+func (m *Smap) addProxy(pi *daemonInfo) {
 	m.Pmap[pi.DaemonID] = pi
 	m.Version++
 }
@@ -179,7 +174,7 @@ func (m *Smap) get(sid string) *daemonInfo {
 	return si
 }
 
-func (m *Smap) getProxy(pid string) *proxyInfo {
+func (m *Smap) getProxy(pid string) *daemonInfo {
 	pi, ok := m.Pmap[pid]
 	if !ok {
 		return nil
@@ -216,7 +211,7 @@ func (m *Smap) deepcopy(dst *Smap) {
 	for id, v := range m.Tmap {
 		dst.Tmap[id] = v
 	}
-	dst.Pmap = make(map[string]*proxyInfo, len(m.Pmap))
+	dst.Pmap = make(map[string]*daemonInfo, len(m.Pmap))
 	for id, v := range m.Pmap {
 		dst.Pmap[id] = v
 	}
@@ -239,13 +234,13 @@ func (m *Smap) Dump() {
 
 	fmt.Printf("Proxies\n")
 	for _, v := range m.Pmap {
-		fmt.Printf("\tid = %-15s\turl = %-30s\tPrimary = %v\n", v.DaemonID, v.DirectURL, v.Primary)
+		fmt.Printf("\tid = %-15s\turl = %-30s\n", v.DaemonID, v.DirectURL)
 	}
 
 	fmt.Printf("Primary proxy\n")
 	if m.ProxySI != nil {
-		fmt.Printf("\tid = %-15s\turl = %-30s\tPrimary = %v\n",
-			m.ProxySI.DaemonID, m.ProxySI.DirectURL, m.ProxySI.Primary)
+		fmt.Printf("\tid = %-15s\turl = %-30s\n",
+			m.ProxySI.DaemonID, m.ProxySI.DirectURL)
 	}
 }
 

--- a/dfc/hrw.go
+++ b/dfc/hrw.go
@@ -36,7 +36,7 @@ func HrwTarget(bucket, objname string, smap *Smap) (si *daemonInfo, errstr strin
 	return
 }
 
-func HrwProxy(smap *Smap, idToSkip string) (pi *proxyInfo, errstr string) {
+func HrwProxy(smap *Smap, idToSkip string) (pi *daemonInfo, errstr string) {
 	smapLock.Lock()
 	defer smapLock.Unlock()
 	if smap.countProxies() == 0 {

--- a/dfc/httpcommon.go
+++ b/dfc/httpcommon.go
@@ -706,7 +706,7 @@ func (h *httprunner) extractsmap(payload map[string]string) (newsmap, oldsmap *S
 	}
 	// old smap
 	oldsmap.Tmap = make(map[string]*daemonInfo)
-	oldsmap.Pmap = make(map[string]*proxyInfo)
+	oldsmap.Pmap = make(map[string]*daemonInfo)
 	v1, ok1 := msg.Value.(map[string]interface{})
 	assert(ok1, fmt.Sprintf("msg (%+v, %T), msg.Value (%+v, %T)", msg, msg, msg.Value, msg.Value))
 	v2, ok2 := v1["tmap"]
@@ -724,7 +724,7 @@ func (h *httprunner) extractsmap(payload map[string]string) (newsmap, oldsmap *S
 		oldsmap.Tmap[sid] = &daemonInfo{}
 	}
 	for pid := range pmapif {
-		oldsmap.Pmap[pid] = &proxyInfo{}
+		oldsmap.Pmap[pid] = &daemonInfo{}
 	}
 	oldsmap.Version = int64(versionf)
 	return

--- a/dfc/metasync.go
+++ b/dfc/metasync.go
@@ -290,7 +290,7 @@ func (y *metasyncer) doSync(revsvec []interface{}) {
 		}
 		for pid, pi := range smap4bcast.Pmap {
 			if _, ok := smapSynced.Pmap[pid]; !ok {
-				y.pending.diamonds[pid] = &pi.daemonInfo
+				y.pending.diamonds[pid] = pi
 			}
 		}
 	}

--- a/dfc/target.go
+++ b/dfc/target.go
@@ -219,10 +219,10 @@ func (t *targetrunner) getPrimaryURLAndSI() (string, *daemonInfo) {
 	}
 
 	if t.smap.ProxySI.DaemonID != "" {
-		return t.smap.ProxySI.DirectURL, &t.smap.ProxySI.daemonInfo
+		return t.smap.ProxySI.DirectURL, t.smap.ProxySI
 	}
 
-	return ctx.config.Proxy.Primary.URL, &t.smap.ProxySI.daemonInfo
+	return ctx.config.Proxy.Primary.URL, t.smap.ProxySI
 }
 
 //===========================================================================================


### PR DESCRIPTION
Primary field in proxyInfo was not used and was a source of confusion.
Removing the field made proxyInfo struct the same as struct daemonInfo, so the next step was to replace proxyInfo with daemonInfo.

Proxy tests passed. 