### PR TITLE
Enable clients to use dfc as an HTTP proxy

### DIFF
--- a/dfc/config.go
+++ b/dfc/config.go
@@ -162,6 +162,7 @@ type l4cnf struct {
 type httpcnf struct {
 	MaxNumTargets int    `json:"max_num_targets"`    // estimated max num targets (to count idle conns)
 	UseHTTPS      bool   `json:"use_https"`          // use HTTPS instead of HTTP
+	UseAsProxy    bool   `json:"use_as_proxy"`       // use DFC as an HTTP proxy
 	Certificate   string `json:"server_certificate"` // HTTPS: openssl certificate
 	Key           string `json:"server_key"`         // HTTPS: openssl key
 }

--- a/dfc/gcp.go
+++ b/dfc/gcp.go
@@ -24,6 +24,8 @@ import (
 )
 
 const (
+	gcsURL = "http://storage.googleapis.com"
+
 	gcpDfcHashType = "x-goog-meta-dfc-hash-type"
 	gcpDfcHashVal  = "x-goog-meta-dfc-hash-val"
 

--- a/dfc/setup/config.sh
+++ b/dfc/setup/config.sh
@@ -73,6 +73,7 @@ $FSPATHS
 		"http": {
 			"max_num_targets":    16,
 			"use_https":          false,
+			"use_as_proxy":       false,
 			"server_certificate": "server.pem",
 			"server_key":         "server.key"
 		}


### PR DESCRIPTION
Clients can `export http_proxy=<proxy-url>`and this will let them start using dfc immediately.

Manual testing:

1. Download https://github.com/NVlabs/dlinputs.
2. `$ export http_proxy=http://localhost:8080`
2. `$ ./show-input http://storage.googleapis.com/lpr-ocr/uw3-lines.tgz`
