### PR TITLE
Fix more races in DFC

### DIFF
--- a/dfc/atime.go
+++ b/dfc/atime.go
@@ -35,10 +35,6 @@ type atimerunner struct {
 
 func (r *atimerunner) run() error {
 	glog.Infof("Starting %s", r.name)
-	r.chstop = make(chan struct{}, 4)
-	r.chfqn = make(chan string, chfqnSize)
-	r.atimemap = &atimemap{m: make(map[string]time.Time, atimeCacheIni)}
-
 	ticker := time.NewTicker(atimeSyncTime)
 loop:
 	for {

--- a/dfc/daemon.go
+++ b/dfc/daemon.go
@@ -435,10 +435,35 @@ func dfcinit() {
 		if iostatverok() {
 			ctx.rg.add(&iostatrunner{}, xiostat)
 		}
+
 		if ctx.config.FSKeeper.Enabled {
 			ctx.rg.add(newfskeeper(t), xfskeeper)
 		}
-		ctx.rg.add(&atimerunner{}, xatime)
+
+		ctx.rg.add(&atimerunner{
+			chstop:   make(chan struct{}, 4),
+			chfqn:    make(chan string, chfqnSize),
+			atimemap: &atimemap{m: make(map[string]time.Time, atimeCacheIni)},
+		}, xatime)
+
+		// L. Ding:
+		// To fix a race between target run() and storage stats run() DFC's runner start doesn't have a
+		// concept of sequence, all runners are started without a clean way of making sure all fields
+		// needed by a runner are initialized. The code should be reworked to include a clean way of
+		// initializing all runnners sequentilly based on runner's dependency, so when runners' run()
+		// is called, they have all their needed fields created and initialized.
+		// Here is one example, when targetrunner.run() and storstatsrunner.run() both are running,
+		// ctx.mountpaths.Available is supposed to be filled by targetrunner when it calls startupMpaths(),
+		// but storstatsrunner.run() started to use it, resulted in the read/write race.
+		ctx.mountpaths.Available = make(map[string]*mountPath, len(ctx.config.FSpaths))
+		ctx.mountpaths.Offline = make(map[string]*mountPath, len(ctx.config.FSpaths))
+		if t.testingFSPpaths() {
+			glog.Infof("Warning: configuring %d fspaths for testing", ctx.config.TestFSP.Count)
+			t.testCachepathMounts()
+		} else {
+			t.fspath2mpath()
+			t.mpath2Fsid() // enforce FS uniqueness
+		}
 	}
 	ctx.rg.add(&sigrunner{}, xsignal)
 }

--- a/dfc/stats.go
+++ b/dfc/stats.go
@@ -266,6 +266,8 @@ func (r *proxystatsrunner) addL(name string, val int64) {
 		assert(false, "Invalid stats name "+name)
 	}
 	*v += val
+	// L. Ding:
+	// This causes a race between this line and the 'logged = true' line in log().
 	s.logged = false
 }
 
@@ -322,6 +324,12 @@ func (r *storstatsrunner) log() (runlru bool) {
 		riostat.Lock()
 		r.CPUidle = riostat.CPUidle
 		for dev, iometrics := range riostat.Disk {
+			// L. Ding:
+			// This is not really a 'copy', iometrics is a map, this assignment makes storstatsrunner
+			// and iostatrunner share the same 'deviometrics', which causes races in other places, for
+			// example, in target.go, when responding to http get stats request, json marshal only
+			// acquired storstatsrunner's lock, but never acquired iostatrunner's lock, which causes
+			// read/write race.
 			r.Disk[dev] = iometrics // copy
 			if riostat.isZeroUtil(dev) {
 				continue // skip zeros

--- a/dfc/target.go
+++ b/dfc/target.go
@@ -211,7 +211,12 @@ func (t *targetrunner) unregister() (int, error) {
 
 // getPrimaryURLAndSI is a helper function to return primary proxy's URL and daemon info
 // if smap is not synced, primary proxy is from config, otherwise from target's smap
+// smap lock is acquired to avoid race between this function and other smap access (for example,
+// receiving smap during metasync)
 func (t *targetrunner) getPrimaryURLAndSI() (string, *daemonInfo) {
+	smapLock.Lock()
+	defer smapLock.Unlock()
+
 	if t.smap.ProxySI == nil {
 		return ctx.config.Proxy.Primary.URL, nil
 	}
@@ -332,6 +337,8 @@ func (t *targetrunner) httpobjget(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// L. Ding: A race here between this call and other lbmap access including receiving lbmap during
+	//          metasync.
 	islocal, errstr, errcode := t.checkLocalQueryParameter(bucket, r)
 	if errstr != "" {
 		t.invalmsghdlr(w, r, errstr, errcode)
@@ -774,6 +781,9 @@ func (t *targetrunner) httphealth(w http.ResponseWriter, r *http.Request) {
 	jsbytes, err := json.Marshal(status)
 	assert(err == nil, err)
 	ok := t.writeJSON(w, r, jsbytes, "thealthstatus")
+
+	smapLock.Lock()
+	defer smapLock.Unlock()
 	if ok && t.smap.ProxySI != nil && from == t.smap.ProxySI.DaemonID {
 		t.kalive.heardFrom(t.smap.ProxySI.DaemonID, false /* reset */)
 	}
@@ -1172,24 +1182,25 @@ func (t *targetrunner) listCachedObjects(bucket string, msg *GetMsg) (outbytes [
 	return
 }
 
-func (t *targetrunner) prepareLocalObjectList(bucket string, msg *GetMsg) (bucketList *BucketList, err error) {
+func (t *targetrunner) prepareLocalObjectList(bucket string, msg *GetMsg) (*BucketList, error) {
 	type mresp struct {
 		infos *allfinfos
 		err   error
 	}
+
 	ch := make(chan *mresp, len(ctx.mountpaths.Available))
 	wg := &sync.WaitGroup{}
-	isLocal := t.islocalBucket(bucket)
 
 	// function to traverse one mountpoint
 	walkMpath := func(dir string) {
 		defer wg.Done()
 		r := &mresp{t.newFileWalk(bucket, msg), nil}
 
-		if _, err = os.Stat(dir); err != nil {
+		if _, err := os.Stat(dir); err != nil {
 			if !os.IsNotExist(err) {
 				r.err = err
 			}
+
 			// it means there was no PUT(for local bucket) or GET(for cloud bucket - cache is empty) yet
 			// Not an error, just skip the path
 			ch <- r
@@ -1197,10 +1208,11 @@ func (t *targetrunner) prepareLocalObjectList(bucket string, msg *GetMsg) (bucke
 		}
 
 		r.infos.rootLength = len(dir) + 1 // +1 for separator between bucket and filename
-		if err = filepath.Walk(dir, r.infos.listwalkf); err != nil {
+		if err := filepath.Walk(dir, r.infos.listwalkf); err != nil {
 			glog.Errorf("Failed to traverse path %q, err: %v", dir, err)
 			r.err = err
 		}
+
 		ch <- r
 	}
 
@@ -1208,17 +1220,19 @@ func (t *targetrunner) prepareLocalObjectList(bucket string, msg *GetMsg) (bucke
 	// If any mountpoint traversing fails others keep running until they complete.
 	// But in this case all collected data is thrown away because the partial result
 	// makes paging inconsistent
+	isLocal := t.islocalBucket(bucket)
 	for mpath := range ctx.mountpaths.Available {
 		wg.Add(1)
-		localdir := ""
+		var localDir string
 		if isLocal {
-			localdir = filepath.Join(makePathLocal(mpath), bucket)
+			localDir = filepath.Join(makePathLocal(mpath), bucket)
 		} else {
-			localdir = filepath.Join(makePathCloud(mpath), bucket)
+			localDir = filepath.Join(makePathCloud(mpath), bucket)
 		}
 
-		go walkMpath(localdir)
+		go walkMpath(localDir)
 	}
+
 	wg.Wait()
 	close(ch)
 
@@ -1254,15 +1268,17 @@ func (t *targetrunner) prepareLocalObjectList(bucket string, msg *GetMsg) (bucke
 		marker = allfinfos[pageSize-1].Name
 	}
 
-	bucketList = &BucketList{
+	bucketList := &BucketList{
 		Entries:    allfinfos,
 		PageMarker: marker,
 	}
+
 	if strings.Contains(msg.GetProps, GetTargetURL) {
 		for _, e := range bucketList.Entries {
 			e.TargetURL = t.si.DirectURL
 		}
 	}
+
 	return bucketList, nil
 }
 
@@ -2241,10 +2257,13 @@ func (t *targetrunner) httpdaeget(w http.ResponseWriter, r *http.Request) {
 		assert(err == nil, err)
 		t.writeJSON(w, r, jsbytes, "httpdaeget")
 	case GetWhatStats:
-		rr := getstorstatsrunner()
-		rr.Lock()
-		jsbytes, err = json.Marshal(rr)
-		rr.Unlock()
+		storageStatsRunner := getstorstatsrunner()
+		ioStatsRunner := getiostatrunner()
+		storageStatsRunner.Lock()
+		ioStatsRunner.Lock()
+		jsbytes, err = json.Marshal(storageStatsRunner)
+		ioStatsRunner.Unlock()
+		storageStatsRunner.Unlock()
 		assert(err == nil, err)
 	default:
 		s := fmt.Sprintf("Unexpected GetMsg <- JSON [%v]", msg)
@@ -2563,17 +2582,6 @@ func (t *targetrunner) mpath2Fsid() (fsmap map[syscall.Fsid]string) {
 }
 
 func (t *targetrunner) startupMpaths() {
-	// fill-in mpaths
-	ctx.mountpaths.Available = make(map[string]*mountPath, len(ctx.config.FSpaths))
-	ctx.mountpaths.Offline = make(map[string]*mountPath, len(ctx.config.FSpaths))
-	if t.testingFSPpaths() {
-		glog.Infof("Warning: configuring %d fspaths for testing", ctx.config.TestFSP.Count)
-		t.testCachepathMounts()
-	} else {
-		t.fspath2mpath()
-		t.mpath2Fsid() // enforce FS uniqueness
-	}
-
 	for mpath := range ctx.mountpaths.Available {
 		cloudbctsfqn := makePathCloud(mpath)
 		if err := CreateDir(cloudbctsfqn); err != nil {


### PR DESCRIPTION
1. Race between target runner and storeage stats runner during start up
2. Race between storage stats runner and io stats runner
3. Race between atime runner start and object get
4. Race in list bucket's file walk (different walkers shared the same variable 'err')
5. Race between target register/unregister and receiving smap during metasync
6. Race between target health check and smap receive during metasync
7. Commented a few places to point out race conditions; I understand locks are not acquired
   for performance reasons, but correctness is more important, performance impact of locks needs
   to be benchmarked and if it is an issue, it can be address in other ways, for example, avoid
   lock completely.

@VladimirMarkelov @liangdrew @sasanap @alex-aizman 