### PR TITLE
Fix multiple response.WriteHeader calls bug

### DIFF
--- a/dfc/target.go
+++ b/dfc/target.go
@@ -426,7 +426,8 @@ existslocally:
 	written, err := io.CopyBuffer(w, file, buf)
 	if err != nil {
 		errstr = fmt.Sprintf("Failed to send file %s, err: %v", fqn, err)
-		t.invalmsghdlr(w, r, errstr)
+		glog.Errorln(t.richHTTPError(r, errstr, http.StatusInternalServerError, 1))
+		t.statsif.add("numerr", 1)
 		return
 	}
 	if !coldget {


### PR DESCRIPTION
[io.CopyBuffer()](https://github.com/NVIDIA/dfcpub/compare/zero-change-debug?expand=1#diff-55511de5ecebac432bae78861a0686a5R426) implicitly calls `WriteHeader()`. [http.Error()](https://github.com/NVIDIA/dfcpub/compare/zero-change-debug?expand=1#diff-1ae6ff57d44b5dff7d5b9b647c4a75b9R687) calls `WriteHeader()` as well, so if an error was returned from `io.CopyBuffer()`, a `multiple response.WriterHeader calls` error occurred.